### PR TITLE
Feature/26/stress testing aura port

### DIFF
--- a/miner/stress_aura.go
+++ b/miner/stress_aura.go
@@ -157,9 +157,9 @@ func makeGenesis(faucets []*ecdsa.PrivateKey, sealers []*ecdsa.PrivateKey) *core
 			Ethash:              nil,
 			Clique:              nil,
 			Aura: &params.AuraConfig{
-				Period:      uint64(rand.Intn(5)),
+				Period:      uint64(rand.Intn(5)) + 1,
 				Epoch:       600,
-				Authorities: nil,
+				Authorities: make([]common.Address, len(sealers)),
 				Difficulty:  nil,
 				Signatures:  nil,
 			},
@@ -195,6 +195,8 @@ func makeGenesis(faucets []*ecdsa.PrivateKey, sealers []*ecdsa.PrivateKey) *core
 	for i, signer := range signers {
 		genesis.Config.Aura.Authorities[i] = signer
 	}
+
+	genesis.Coinbase = signers[0]
 	// Return the genesis block for initialization
 	return genesis
 }
@@ -232,7 +234,6 @@ func makeSealer(genesis *core.Genesis) (*node.Node, *eth.Ethereum, error) {
 			GasFloor: genesis.GasLimit * 9 / 10,
 			GasCeil:  genesis.GasLimit * 11 / 10,
 			GasPrice: big.NewInt(1),
-			Recommit: time.Second,
 		},
 	})
 	if err != nil {

--- a/miner/stress_aura.go
+++ b/miner/stress_aura.go
@@ -1,0 +1,244 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// +build none
+
+// This file contains a miner stress test based on the Clique consensus engine.
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"io/ioutil"
+	"math/big"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/fdlimit"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/miner"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	chainId = rand.Intn(1000) + 100
+)
+
+func main() {
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	fdlimit.Raise(2048)
+
+	// Generate a batch of accounts to seal and fund with
+	faucets := make([]*ecdsa.PrivateKey, 128)
+	for i := 0; i < len(faucets); i++ {
+		faucets[i], _ = crypto.GenerateKey()
+	}
+	sealers := make([]*ecdsa.PrivateKey, 4)
+	for i := 0; i < len(sealers); i++ {
+		sealers[i], _ = crypto.GenerateKey()
+	}
+	// Create an Aura network genesis
+	genesis := makeGenesis(faucets, sealers)
+
+	var (
+		nodes  []*eth.Ethereum
+		enodes []*enode.Node
+	)
+
+	for _, sealer := range sealers {
+		// Start the node and wait until it's up
+		stack, ethBackend, err := makeSealer(genesis)
+		if err != nil {
+			panic(err)
+		}
+		defer stack.Close()
+
+		for stack.Server().NodeInfo().Ports.Listener == 0 {
+			time.Sleep(250 * time.Millisecond)
+		}
+		// Connect the node to all the previous ones
+		for _, n := range enodes {
+			stack.Server().AddPeer(n)
+		}
+		// Start tracking the node and its enode
+		nodes = append(nodes, ethBackend)
+		enodes = append(enodes, stack.Server().Self())
+
+		// Inject the signer key and start sealing with it
+		store := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
+		signer, err := store.ImportECDSA(sealer, "")
+		if err != nil {
+			panic(err)
+		}
+		if err := store.Unlock(signer, ""); err != nil {
+			panic(err)
+		}
+	}
+
+	// Iterate over all the nodes and start signing on them
+	time.Sleep(3 * time.Second)
+	for _, node := range nodes {
+		if err := node.StartMining(1); err != nil {
+			panic(err)
+		}
+	}
+	time.Sleep(3 * time.Second)
+
+	// Start injecting transactions from the faucet like crazy
+	nonces := make([]uint64, len(faucets))
+	for {
+		// Pick a random signer node
+		index := rand.Intn(len(faucets))
+		backend := nodes[index%len(nodes)]
+
+		// Create a self transaction and inject into the pool
+		tx, err := types.SignTx(types.NewTransaction(nonces[index], crypto.PubkeyToAddress(faucets[index].PublicKey), new(big.Int), 21000, big.NewInt(100000000000), nil), types.HomesteadSigner{}, faucets[index])
+		if err != nil {
+			panic(err)
+		}
+		if err := backend.TxPool().AddLocal(tx); err != nil {
+			panic(err)
+		}
+		nonces[index]++
+
+		// Wait if we're too saturated
+		if pend, _ := backend.TxPool().Stats(); pend > 2048 {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// makeGenesis creates a custom Clique genesis block based on some pre-defined
+// signer and faucet accounts.
+func makeGenesis(faucets []*ecdsa.PrivateKey, sealers []*ecdsa.PrivateKey) *core.Genesis {
+	// Create a Genesis for aura port
+	genesis := &core.Genesis{
+		Config: &params.ChainConfig{
+			ChainID:             big.NewInt(int64(chainId)),
+			HomesteadBlock:      big.NewInt(0),
+			DAOForkBlock:        big.NewInt(0),
+			DAOForkSupport:      false,
+			EIP150Block:         big.NewInt(0),
+			EIP150Hash:          common.Hash{},
+			EIP155Block:         big.NewInt(0),
+			EIP158Block:         big.NewInt(0),
+			ByzantiumBlock:      big.NewInt(0),
+			ConstantinopleBlock: big.NewInt(0),
+			PetersburgBlock:     big.NewInt(0),
+			IstanbulBlock:       big.NewInt(0),
+			MuirGlacierBlock:    big.NewInt(0),
+			YoloV1Block:         nil,
+			EWASMBlock:          nil,
+			Ethash:              nil,
+			Clique:              nil,
+			Aura: &params.AuraConfig{
+				Period:      uint64(rand.Intn(5)),
+				Epoch:       600,
+				Authorities: nil,
+				Difficulty:  nil,
+				Signatures:  nil,
+			},
+		},
+		Timestamp:  0,
+		ExtraData:  hexutil.MustDecode("0x"),
+		GasLimit:   6000000,
+		Difficulty: big.NewInt(131072),
+	}
+	genesis.GasLimit = 25000000
+
+	genesis.Config.EIP150Hash = common.Hash{}
+
+	genesis.Alloc = core.GenesisAlloc{}
+	for _, faucet := range faucets {
+		genesis.Alloc[crypto.PubkeyToAddress(faucet.PublicKey)] = core.GenesisAccount{
+			Balance: new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil),
+		}
+	}
+	// Sort the signers and embed into the extra-data section
+	signers := make([]common.Address, len(sealers))
+	for i, sealer := range sealers {
+		signers[i] = crypto.PubkeyToAddress(sealer.PublicKey)
+	}
+	for i := 0; i < len(signers); i++ {
+		for j := i + 1; j < len(signers); j++ {
+			if bytes.Compare(signers[i][:], signers[j][:]) > 0 {
+				signers[i], signers[j] = signers[j], signers[i]
+			}
+		}
+	}
+	//genesis.ExtraData = make([]byte, 32+len(signers)*common.AddressLength+65)
+	for i, signer := range signers {
+		genesis.Config.Aura.Authorities[i] = signer
+	}
+	// Return the genesis block for initialization
+	return genesis
+}
+
+func makeSealer(genesis *core.Genesis) (*node.Node, *eth.Ethereum, error) {
+	// Define the basic configurations for the Ethereum node
+	datadir, _ := ioutil.TempDir("", "")
+
+	config := &node.Config{
+		Name:    "geth",
+		Version: params.Version,
+		DataDir: datadir,
+		P2P: p2p.Config{
+			ListenAddr:  "0.0.0.0:0",
+			NoDiscovery: true,
+			MaxPeers:    25,
+		},
+		NoUSB: true,
+	}
+	// Start the node and configure a full Ethereum node on it
+	stack, err := node.New(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Create and register the backend
+	ethBackend, err := eth.New(stack, &eth.Config{
+		Genesis:         genesis,
+		NetworkId:       genesis.Config.ChainID.Uint64(),
+		SyncMode:        downloader.FullSync,
+		DatabaseCache:   256,
+		DatabaseHandles: 256,
+		TxPool:          core.DefaultTxPoolConfig,
+		GPO:             eth.DefaultConfig.GPO,
+		Miner: miner.Config{
+			GasFloor: genesis.GasLimit * 9 / 10,
+			GasCeil:  genesis.GasLimit * 11 / 10,
+			GasPrice: big.NewInt(1),
+			Recommit: time.Second,
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = stack.Start()
+	return stack, ethBackend, err
+}


### PR DESCRIPTION
This pull request allows us to stress test the aura port with 4 validators.

`err="invalid timestamp"` is displayed when validator is not within its turn. Its a warning.

![Screenshot from 2020-10-24 12-48-39](https://user-images.githubusercontent.com/26545969/97080408-47c50180-15fb-11eb-8dbd-286b060e5e1b.png)
